### PR TITLE
chore: add common context between pages and app-router

### DIFF
--- a/.changeset/silent-turtles-fry.md
+++ b/.changeset/silent-turtles-fry.md
@@ -1,0 +1,5 @@
+---
+'fuse': patch
+---
+
+Add commont types between the app and pages route to our context object

--- a/examples/next/types/Launch.ts
+++ b/examples/next/types/Launch.ts
@@ -66,7 +66,7 @@ addQueryFields((t) => ({
       limit: t.arg.int(),
       filter: t.arg({ type: FilterInput }),
     },
-    resolve: async (_, args) => {
+    resolve: async (_, args, context) => {
       const filter = args.filter?.rocketId
       const offset = args.offset || 0
       const limit = args.limit || 10

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -18,11 +18,11 @@ import DataloaderPlugin, {
   LoadableNodeOptions,
 } from '@pothos/plugin-dataloader'
 import { DateResolver, JSONResolver } from 'graphql-scalars'
-import { YogaServerOptions } from 'graphql-yoga'
+import { GraphQLParams, YogaServerOptions } from 'graphql-yoga'
 import listPlugin from './pothos-list'
 
 const builder = new SchemaBuilder<{
-  Context: Record<string, unknown>
+  Context: { request: Request; params: GraphQLParams } & Record<string, unknown>
   DefaultFieldNullability: true
   Scalars: {
     JSON: {
@@ -223,7 +223,10 @@ export function node<
     },
     async load(
       ids: Array<Key>,
-      ctx: { headers?: Record<string, string> | undefined },
+      ctx: { request: Request; params: GraphQLParams } & Record<
+        string,
+        unknown
+      >,
     ) {
       const translatedIds = ids.map((id) => {
         try {


### PR DESCRIPTION
As I don't really have a good idea yet on how to inherit the `context` we create for the pages/app router and how to add the user context on top I have resorted to already defining the common shape.