### PR TITLE
chore(core): convert to existsSync

### DIFF
--- a/.changeset/twelve-emus-jog.md
+++ b/.changeset/twelve-emus-jog.md
@@ -1,0 +1,5 @@
+---
+'fuse': patch
+---
+
+Replace fs.exists with existsSync

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -105,7 +105,7 @@ prog
           ? path.resolve(baseDirectory, 'src')
           : baseDirectory
 
-        if (!(await fs.exists(path.resolve(base, 'fuse')))) {
+        if (!existsSync(path.resolve(base, 'fuse'))) {
           await fs.mkdir(path.resolve(base, 'fuse'))
         }
 


### PR DESCRIPTION
`fs.exists` still bugs out in some environments