### PR TITLE
Fix GitHub stars button when API errors

### DIFF
--- a/website/src/components/StarOnGithub.tsx
+++ b/website/src/components/StarOnGithub.tsx
@@ -26,12 +26,12 @@ export function StarOnGithub({ stars = 0 }: StarOnGithubProps) {
     >
       <GithubLogo className="h-5 w-5" />
       Star on GitHub
-      {stars && (
-        <div className="inline-flex h-7 items-center gap-1.5 rounded-xl border border-gravel-200 bg-gravel-50 px-2.5">
-          <Star className="h-4 w-4" />
+      <div className="inline-flex h-7 items-center gap-1.5 rounded-xl border border-gravel-200 bg-gravel-50 px-2.5">
+        <Star className="h-4 w-4" />
+        {stars > 50 ? (
           <span ref={countUpRef} className="text-sm tabular-nums" />
-        </div>
-      )}
+        ) : null}
+      </div>
     </ButtonLink>
   )
 }


### PR DESCRIPTION
Before ([current website](https://fusedata.dev/)):

<img width="1159" alt="image" src="https://github.com/StellateHQ/fuse/assets/4032071/b41f0b7e-6968-4450-8896-53eba6dce61d">

After:
<img width="1171" alt="image" src="https://github.com/StellateHQ/fuse/assets/4032071/8baa0ea3-0a79-4952-946a-4c3cff50558e">

Note: rerunning the build + deploy might fix this as well since the data is fetched inside `getStaticProps`, but this would prevent future issues (e.g. GitHub being down during build) from rendering a weird button